### PR TITLE
Develop

### DIFF
--- a/src/agent/copy_generator.py
+++ b/src/agent/copy_generator.py
@@ -31,11 +31,14 @@ class CopyGenerator:
                     "あなたはプロのコピーライターです。",
                 )
             ]
-            + state["messages"]
             + [
                 (
                     "human",
-                    "会話の内容をもとにキャッチコピーを1つ生成してください。結果のみ出力してください。",
+                    f"""以下のテーマで、キャッチコピーを1つ生成してください。必ず結果のみ出力してください。
+                    <theme_copy>
+                    {state['theme_copy']}
+                    </theme_copy>
+                    """,
                 )
             ]
         )
@@ -49,7 +52,7 @@ class CopyGenerator:
 
         return {
             "messages": response,
-            "copy": response.content,
+            "draft_copy": response.content,
             "display_message_dict": display_message_dict,
         }
 
@@ -61,11 +64,14 @@ class CopyGenerator:
                     "あなたはプロのコピーライターです。",
                 )
             ]
-            + state["messages"]
             + [
                 (
                     "human",
-                    "1つのキャッチコピーを改善してください。結果のみ出力してください。",
+                    f"""多角的な観点で、以下のキャッチコピーを改善してください。必ず結果のみ出力してください。
+                    <draft_copy>
+                    {state['draft_copy']}
+                    </draft_copy>
+                    """,
                 )
             ]
         )
@@ -79,7 +85,6 @@ class CopyGenerator:
 
         return {
             "messages": response,
-            "copy": response.content,  # TODO: 削除
             "display_message_dict": display_message_dict,
         }
 

--- a/src/agent/state.py
+++ b/src/agent/state.py
@@ -12,7 +12,8 @@ class DisplayMessageDict(TypedDict):
 class AgentState(TypedDict):
     messages: Annotated[list, add_messages]
 
-    copy: str
+    theme_copy: str
+    draft_copy: str
     search_query: str
 
     is_finished: bool

--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -6,9 +6,9 @@ from langchain_core.tools.base import InjectedToolCallId
 
 @tool
 def handoff_to_copy_generator(
-    copy_request: Annotated[
+    theme_copy: Annotated[
         str,
-        "コピー生成の要求。どのようなコピー文を生成すべきかという内容が記載されている。",
+        "コピーのテーマ。どのようなコピー文を生成すべきかという内容が記載されている。",
     ],
     tool_call_id: Annotated[str, InjectedToolCallId],
 ) -> dict:
@@ -29,7 +29,10 @@ def handoff_to_copy_generator(
 
     return {
         "goto": "copy_generator_subgraph",
-        "update": {"messages": [tool_msg]},
+        "update": {
+            "messages": [tool_msg],
+            "theme_copy": theme_copy,
+        },
     }
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,7 @@ from models.bedrock_img_gen_model import BedrockImageModel
 from models.llm import LLM
 from utils.app_util import display_message, display_messages
 
-MODEL = "claude-3-5"
+MODEL = "claude-3-7-sonnet"
 IMG_GEN_MODEL = "nova-canvas"
 THREAD_ID = "1"
 TEMPERATURE = 0.2

--- a/src/models/llm.py
+++ b/src/models/llm.py
@@ -9,14 +9,17 @@ class LLM:
         self.model = self._initialize_llm(model_name, temperature)
 
     def _initialize_llm(self, model_name: str, temperature: float) -> BaseChatModel:
-        if model_name == "claude-3-5":
-            return ChatBedrockConverse(
-                model="anthropic.claude-3-5-sonnet-20241022-v2:0",
-                region_name="us-west-2",
-                temperature=temperature,
-            )
+        if model_name == "claude-3-7-sonnet":
+            model_id = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        elif model_name == "claude-3-5-haiku":
+            model_id = "us.anthropic.claude-3-5-haiku-20241022-v1:0"
         else:
             raise ValueError(f"Model name {model_name} not supported.")
+        return ChatBedrockConverse(
+            model=model_id,
+            region_name="us-west-2",
+            temperature=temperature,
+        )
 
     def __call__(self, input: LanguageModelInput) -> BaseMessage:
         """LLMの呼び出し"""


### PR DESCRIPTION
## title

Supervisorでの出力（ToolMessage）を含む会話履歴を，SubAgent側のLLM（ツール未設定）の入力に利用しているため発生するバグの改修．

## description

以下を修正しています．

- コピー生成サブエージェント側で，state["messages"]を入力として利用しないように修正
- claude 3.7 sonnet や 3.5 haiku を利用できるように修正（デバッグ時はhaikuの方がレイテンシ少なくて良いかも）