### PR TITLE
Bugfix/use correct modelid

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -19,6 +19,8 @@ def main() -> None:
     st.set_page_config(
         page_title="Streamlit×LangGraph MultiAgent | 広告素材生成アプリケーション",
         page_icon="🤖",
+        layout="wide",
+        initial_sidebar_state="auto",
     )
     st.title("Streamlit×LangGraph MultiAgent | 広告素材生成アプリケーション")
 

--- a/src/app.py
+++ b/src/app.py
@@ -8,7 +8,7 @@ from models.bedrock_img_gen_model import BedrockImageModel
 from models.llm import LLM
 from utils.app_util import display_message, display_messages
 
-MODEL = "claude-3-7-sonnet"
+MODEL = "claude-3-7-sonnet" # you can use "claude-3-5-haiku"
 IMG_GEN_MODEL = "nova-canvas"
 THREAD_ID = "1"
 TEMPERATURE = 0.2
@@ -27,15 +27,11 @@ def main() -> None:
     # Init Actors
     llm = LLM(MODEL, TEMPERATURE)
     bedrock_image_model = BedrockImageModel(IMG_GEN_MODEL)
-
     copy_generator = CopyGenerator(llm)
     image_generator = ImageGenerator(llm, bedrock_image_model)
-
     supervisor = Supervisor(llm, copy_generator, image_generator)
 
-    # Session State
-    if "is_start_chat" not in st.session_state:
-        st.session_state.is_start_chat = False
+    # Set session state
     if "display_messages" not in st.session_state:
         init_display_message_dict = {
             "role": "assistant",
@@ -63,18 +59,14 @@ def main() -> None:
             "content": user_input,
         }
         st.session_state.display_messages.append(display_message_dict)
-        st.session_state.is_start_chat = True
-
-    # Display Messages
-    display_messages(st.session_state.display_messages)
-
-    if not st.session_state.is_start_chat:
+    else:
         st.stop()
+
+    display_messages(st.session_state.display_messages)
 
     # Core Algorithm
     inputs = {"messages": st.session_state.messages + [HumanMessage(user_input)]}
     config = {"configurable": {"thread_id": THREAD_ID}}
-
     supervisor.write_mermaid_graph()
 
     event_prev = {}
@@ -90,8 +82,9 @@ def main() -> None:
             display_message(display_message_dict)
             st.session_state.display_messages.append(display_message_dict)
 
-        # Update Message History
+        # Get the latest message list (cumulative list that updates with each loop)
         messages = event[1].get("messages")
+    # After the loop, add the final message list to the session
     st.session_state.messages.extend(messages)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -49,6 +49,9 @@ def main() -> None:
     if "messages" not in st.session_state:
         st.session_state.messages = []
 
+    # Display All Messages
+    display_messages(st.session_state.display_messages)
+
     # User Input
     user_input = st.chat_input("メッセージを入力してください:")
     if user_input:
@@ -58,11 +61,10 @@ def main() -> None:
             "icon": "👤",
             "content": user_input,
         }
+        display_message(display_message_dict)
         st.session_state.display_messages.append(display_message_dict)
     else:
         st.stop()
-
-    display_messages(st.session_state.display_messages)
 
     # Core Algorithm
     inputs = {"messages": st.session_state.messages + [HumanMessage(user_input)]}

--- a/src/models/bedrock_img_gen_model.py
+++ b/src/models/bedrock_img_gen_model.py
@@ -65,7 +65,7 @@ class BedrockImageModel:
         try:
             response = self.client.invoke_model(
                 body=body,
-                modelId="amazon.olympus-image-generator-v1:0",
+                modelId="amazon.nova-canvas-v1:0",
                 accept=accept,
                 contentType=content_type,
             )


### PR DESCRIPTION
## 2025/03/03変更分
- amazon nova canvasのモデル名が誤ってたので修正しました．
- st.set_page_configの部分，wideに対応してなかったので対応しました（意図的に除去してたら除去いただいて問題ないです．）

## 2025/03/04変更分
- `st.session_state.is_start_chat` は不要なので除去
  - display_messagesの実行タイミングも変更している
- `for event in supervisor.graph.stream` の最後らへんの処理にコメントを付与（意図汲んでるつもりですが間違ってたらご指摘ください）．その他の部分も微妙にコメント付与したり改行消したりしてます．