### PR TITLE
Bugfix/error image font compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@
 - **StreamlitによるWebアプリケーション化**: Agentのメモリ機能を利用し、マルチターンの会話が可能な実装としている。
 - **Amazon Bedrockの利用**: LLMとしてClaude 3.7 Sonnet, 画像生成AIとしてAmazon Nova Canvasを利用している。
 
+## 実行環境
+
+以下の環境で動作確認済みである。
+
+- OS: Ubuntu 22.04.5 LTS
+- Python: 3.12.5
+
 ## 使い方
 ### 1. リポジトリのクローン
 ```bash


### PR DESCRIPTION
https://github.com/yamato0811/langgraph-bedrock-multi-agent/issues/8 の対応．
本エラーは，画像生成時にBedrock側のコンテンツフィルターに抵触した場合のロジックで発生している．具体的には，エラー画像表示の際に，フォントファイルを読み込むように指定しているが，その部分でエラー`OSError: cannot open resource`が発生している．
本エラー原因は，実行環境に依っては，`/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf`が無い or アクセス権限が無いため．

一旦上記のフォントファイルは利用せず，デフォルトのフォントでコンテンツフィルター抵触時のエラーメッセージを表示するように修正．合わせて，エラーメッセージを可読性高いように改行した．コンテンツフィルター抵触時，以下の画像が表示される．

![Screenshot from 2025-03-17 14-20-08](https://github.com/user-attachments/assets/19d3ce24-d5c8-4670-928d-52a0c36e86ad)


あと，READMEに開発環境の情報も追記しました．